### PR TITLE
Create repositories.conf

### DIFF
--- a/specs/repositories.conf
+++ b/specs/repositories.conf
@@ -1,0 +1,15 @@
+# This file attempts to tie a version of `extra-scidb-libs` with the 
+# exact release tag of constituent plugins and shim
+
+# @JAKinchen to decide on final configuration and location of this config file
+
+# @JAKinchen (or person building `extra-scidb-libs`) to change version tag appropriately when a constituent component's version is bumped up
+#            and when `extra-scidb-libs` has to be rebuilt
+extra-scidb-libs-version: 18.1.1 
+
+# Now the release tags for the constituent components
+accelerated_io_tools:     rel18.1.1
+grouped_aggregate:        rel18.1.1
+equi_join:                rel18.1.1
+superfunpack:             rel18.1.1
+shim:                     rel18.1.1


### PR DESCRIPTION
Not having an exact commit tied to a build is a problematic issue when deploying in the field. We have no idea of knowing which version of the software is being used at a production system.

Also issues as in #5 might arise. 

To resolve this, I discussed with @JAKinchen and he agreed to help integrate from specific tags of the component repositories. 

I am proposing a config file here to guide which tag to pull (@JAKinchen to review). 