### PR TITLE
Exit on error, dynamic Shim username, sort Makefiles

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,1 @@
+/var/lib/shim/conf

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-sed -i "s/LOGNAME/scidb/" /var/lib/shim/conf 
+scidbuser=`ps axfo user:64,cmd | grep scidb | grep dbname | head -n 1 | cut -d ' ' -f 1`
+sed -i "s/LOGNAME/$scidbuser/" /var/lib/shim/conf
 basepath=$(cat /opt/scidb/18.1/etc/config.ini | grep base-path | cut -d= -f2)
-sed -i "s:\[INSTANCE_0_DATA_DIR\]:$basepath/0/0/tmp:" /var/lib/shim/conf 
-if test -f /etc/init.d/shimsvc; then /etc/init.d/shimsvc start;fi
+sed -i "s:\[INSTANCE_0_DATA_DIR\]:$basepath/0/0/tmp:" /var/lib/shim/conf
+if test -f /etc/init.d/shimsvc; then /etc/init.d/shimsvc restart;fi

--- a/extra-scidb-libs.sh
+++ b/extra-scidb-libs.sh
@@ -37,18 +37,18 @@ function downloadLibs ()
     params=("$@")
     for i in $(seq 1 "$((${#params[@]}/2))")
     do
-	lib_name=${params[0]}
-	arch_name=${params[1]}
-	dir_name=$lib_name
+        lib_name=${params[0]}
+        arch_name=${params[1]}
+        dir_name=$lib_name
 
-	params=("${params[@]:2}")
+        params=("${params[@]:2}")
 
         git clone https://github.com/Paradigm4/$lib_name.git
         cd $work_dir/$lib_name
         git checkout $arch_name
         cd ..
-	mv $work_dir/$lib_name $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/
-	rm -rf $work_dir/$lib_name
+        mv $work_dir/$lib_name $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/
+        rm -rf $work_dir/$lib_name
     done
 }
 
@@ -60,8 +60,8 @@ function create_makefile()
     echo "all:" > $make_dir/Makefile
     for lib_name in "${dirs[@]}"
     do
-	makefiles=($(find . -name Makefile | sort | grep $lib_name | xargs -n1 dirname))
-	echo -e "\t\$(MAKE) -C ${makefiles[0]}" >> $make_dir/Makefile
+        makefiles=($(find . -name Makefile | sort | grep $lib_name | xargs -n1 dirname))
+        echo -e "\t\$(MAKE) -C ${makefiles[0]}" >> $make_dir/Makefile
     done
     cd $work_dir
 }
@@ -88,11 +88,11 @@ mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
 
 # The following array should contain tuples of the repo name and the branch to get.
 declare -a libs=("superfunpack" "rel18.1.1"
-		 "grouped_aggregate" "rel18.1.1"
+                 "grouped_aggregate" "rel18.1.1"
                  "accelerated_io_tools" "rel18.1.1"
                  "equi_join" "rel18.1.1"
                  "shim" "rel18.1.1"
-		)
+                )
 
 downloadLibs "${libs[@]}"
 
@@ -107,7 +107,7 @@ if [[ "$1" == "rpm" || "$1" == "both" ]]; then
     create_makefile $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
 
     cp $source_dir/specs/conf $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/shim/conf
-    
+
     tar -zcvf extra-scidb-libs-${SCIDB_VER:=18.1}.tar.gz extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
 
     until ls -l $work_dir/rpmbuild/SOURCES > /dev/null; do sleep 1; done
@@ -131,50 +131,47 @@ if [[ "$1" == "deb" || "$1" == "both" ]]; then
     make SCIDB=$SCIDB_INSTALL_PATH
 
     if [ $? -eq 0 ]; then
-	mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/lib/scidb/plugins
-	cp */*.so $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/lib/scidb/plugins
+        mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/lib/scidb/plugins
+        cp */*.so $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/lib/scidb/plugins
 
-	mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/bin
-	cp shim/shim $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/bin
+        mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/bin
+        cp shim/shim $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$SCIDB_INSTALL_PATH/bin
 
-	mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d
-	cp shim/init.d/shimsvc $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d
-	chmod 755 $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d/shimsvc
-	
-	mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
-	cp $source_dir/specs/conf $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
-	cp -aR shim/wwwroot $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
+        mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d
+        cp shim/init.d/shimsvc $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d
+        chmod 755 $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/etc/init.d/shimsvc
 
-	mkdir $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
-	m4 -DVERSION=${SCIDB_VER:=18.1} $source_dir/debian/control > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/control
-	hname=$(hostname); hname="$hname.$(hostname -d)"
-	m4 -DVERSION=${SCIDB_VER:=18.1} -DDATE="$(date)" -DHOSTNAME=$hname $source_dir/debian/copyright > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/copyright
+        mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
+        cp $source_dir/specs/conf $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
+        cp -aR shim/wwwroot $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/var/lib/shim
 
-	userinfo=$(getent passwd $(whoami) | cut -d: -f 5)
-	[[ $userinfo == "" ]] && userinfo=$(whoami)
-	userinfo="$userinfo <$(whoami)@paradigm4.com>"
-	m4 -DVERSION=${SCIDB_VER:=18.1} -DUSERINFO="$userinfo" $source_dir/debian/changelog > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/changelog
+        mkdir $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        m4 -DVERSION=${SCIDB_VER:=18.1} $source_dir/debian/control > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/control
+        hname=$(hostname); hname="$hname.$(hostname -d)"
+        m4 -DVERSION=${SCIDB_VER:=18.1} -DDATE="$(date)" -DHOSTNAME=$hname $source_dir/debian/copyright > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/copyright
 
-	cp -p $source_dir/debian/compat $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
-	cp -p $source_dir/debian/postinst $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
-	cp -p $source_dir/debian/prerm $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        userinfo=$(getent passwd $(whoami) | cut -d: -f 5)
+        [[ $userinfo == "" ]] && userinfo=$(whoami)
+        userinfo="$userinfo <$(whoami)@paradigm4.com>"
+        m4 -DVERSION=${SCIDB_VER:=18.1} -DUSERINFO="$userinfo" $source_dir/debian/changelog > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/changelog
 
-	cd $work_dir
+        cp -p $source_dir/debian/compat $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        cp -p $source_dir/debian/postinst $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        cp -p $source_dir/debian/prerm $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
 
-	params=("${libs[@]}")
-	for i in `seq 1 "$((${#params[@]}/2))"`
-	do
-	    lib_name=${params[0]}
-	    rm -rf ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$lib_name
-	    params=("${params[@]:2}")
-	done
+        cd $work_dir
 
-	dpkg-deb --build ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
-	mv ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER.deb $result_dir
-	
+        params=("${libs[@]}")
+        for i in `seq 1 "$((${#params[@]}/2))"`
+        do
+            lib_name=${params[0]}
+            rm -rf ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/$lib_name
+            params=("${params[@]:2}")
+        done
+
+        dpkg-deb --build ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
+        mv ./extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER.deb $result_dir
+
 
     fi
 fi
-
-
-

--- a/extra-scidb-libs.sh
+++ b/extra-scidb-libs.sh
@@ -155,9 +155,11 @@ if [[ "$1" == "deb" || "$1" == "both" ]]; then
         userinfo="$userinfo <$(whoami)@paradigm4.com>"
         m4 -DVERSION=${SCIDB_VER:=18.1} -DUSERINFO="$userinfo" $source_dir/debian/changelog > $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN/changelog
 
-        cp -p $source_dir/debian/compat $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
-        cp -p $source_dir/debian/postinst $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
-        cp -p $source_dir/debian/prerm $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        dest=$work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER/DEBIAN
+        cp -p $source_dir/debian/conffiles $dest
+        cp -p $source_dir/debian/compat    $dest
+        cp -p $source_dir/debian/postinst  $dest
+        cp -p $source_dir/debian/prerm     $dest
 
         cd $work_dir
 

--- a/extra-scidb-libs.sh
+++ b/extra-scidb-libs.sh
@@ -60,7 +60,7 @@ function create_makefile()
     echo "all:" > $make_dir/Makefile
     for lib_name in "${dirs[@]}"
     do
-	makefiles=($(find . -name Makefile | grep $lib_name | xargs -n1 dirname))
+	makefiles=($(find . -name Makefile | sort | grep $lib_name | xargs -n1 dirname))
 	echo -e "\t\$(MAKE) -C ${makefiles[0]}" >> $make_dir/Makefile
     done
     cd $work_dir

--- a/extra-scidb-libs.sh
+++ b/extra-scidb-libs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -xe
 
 function usage
 {

--- a/specs/conf
+++ b/specs/conf
@@ -8,7 +8,7 @@
 scidbport=1239
 instance=0
 tmp=[INSTANCE_0_DATA_DIR]
-user=scidb
+user=LOGNAME
 #max_sessions=50
 #timeout=60
 aio=1

--- a/specs/extra-scidb-libs.spec
+++ b/specs/extra-scidb-libs.spec
@@ -20,7 +20,7 @@ Source0:        %{name}/%{name}.tar.gz
 Requires(post): info
 Requires(preun): info
 
-%description 
+%description
 The Paradigm4 github repository has several prototype operators and functions for SciDB: equi_join, grouped aggregate, accelerated I/O tools, superfunpack, stream and shim.  The package contains the latest version for the current SciDB version.
 
 %prep
@@ -51,7 +51,7 @@ mkdir -p %{buildroot}/etc/init.d
 cp shim/init.d/shimsvc %{buildroot}/etc/init.d
 chmod 0755 %{buildroot}/etc/init.d/shimsvc
 mkdir -p %{buildroot}/var/lib/shim
-cat shim/conf | sed "s/user=scidb/user=LOGNAME/" > %{buildroot}/var/lib/shim/conf
+cp shim/conf %{buildroot}/var/lib/shim/conf
 
 echo %{_scidb_install_path}/lib/scidb/plugins/libsuperfunpack.so > files.lst
 echo %{_scidb_install_path}/lib/scidb/plugins/libgrouped_aggregate.so >> files.lst
@@ -68,9 +68,10 @@ echo /var/lib/shim/conf >> files.lst
 %post
 if test -z "$SCIDB_INSTALL_PATH"; then export SCIDB_INSTALL_PATH=/opt/scidb/18.1; fi
 if test -x /etc/init.d/shimsvc; then /etc/init.d/shimsvc stop;fi
-sed -i "s/LOGNAME/$(logname)/" /var/lib/shim/conf 
+scidbuser=`ps axfo user:64,cmd | grep scidb | grep dbname | head -n 1 | cut -d ' ' -f 1`
+sed -i "s/LOGNAME/$scidbuser/" /var/lib/shim/conf
 basepath=$(cat $SCIDB_INSTALL_PATH/etc/config.ini | grep base-path | cut -d= -f2)
-sed -i "s:\[INSTANCE_0_DATA_DIR\]:$basepath/0/0/tmp:" /var/lib/shim/conf 
+sed -i "s:\[INSTANCE_0_DATA_DIR\]:$basepath/0/0/tmp:" /var/lib/shim/conf
 if test -f /etc/init.d/shimsvc; then /etc/init.d/shimsvc start;fi
 
 %preun

--- a/specs/extra-scidb-libs.spec
+++ b/specs/extra-scidb-libs.spec
@@ -62,7 +62,7 @@ echo %{_scidb_install_path}/bin/shim >> files.lst
 echo /var/lib/shim/wwwroot >> files.lst
 echo /usr/local/share/man/man1/shim.1 >> files.lst
 echo /etc/init.d/shimsvc >> files.lst
-echo /var/lib/shim/conf >> files.lst
+# echo /var/lib/shim/conf >> files.lst
 
 
 %post
@@ -78,6 +78,8 @@ if test -f /etc/init.d/shimsvc; then /etc/init.d/shimsvc start;fi
 if test -f /etc/init.d/shimsvc; then /etc/init.d/shimsvc stop; rm -f /etc/init.d/shimsvc;fi
 
 %files -f files.lst
+
+%config(noreplace) /var/lib/shim/conf
 
 %doc
 


### PR DESCRIPTION
This PR contains a number of small fixes made to the scripts and the configuration files. The changes are detailed in each individual commit. At high level, the changes are:
1. Use `-e` flag in the Bash script to exit on any error - helps catch failures early
1. Sort `find` result to assure top-level `Makefile` is picked
1. Dynamically determine appropriate Shim user name at install time and update Shim configuration file.
1. `restart` Shim service upon install, as opposed to just `start` - this will stop previous Shim installations gracefully
