### PR TITLE
Apache Arrow dependency, setup & install script, build/test on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,41 +11,58 @@ python:
   - "3.6"
 
 env:
-  global: SCIDB_VER=18.1
+  global:
+    - SCIDB_VER=18.1
+    - PKG_VER=1
   matrix:
-    - IMG=debian:8                              TARGET=deb
-    - IMG=ubuntu:trusty                         TARGET=deb
-    - IMG=centos:6                              TARGET=rpm
-    - IMG=rvernica/scidb:${SCIDB_VER}           TARGET=try
-    - IMG=rvernica/scidb:${SCIDB_VER}-trusty    TARGET=try
-    - IMG=rvernica/scidb:${SCIDB_VER}-centos-6  TARGET=try
-    - IMG=rvernica/scidb:${SCIDB_VER}-centos-7  TARGET=try
+    - BUILD_IMG=ubuntu:trusty  DEPLOY_IMG=           TARGET=deb
+    - BUILD_IMG=ubuntu:trusty  DEPLOY_IMG=-trusty    TARGET=deb
+    - BUILD_IMG=centos:6       DEPLOY_IMG=-centos-6  TARGET=rpm
+    - BUILD_IMG=centos:6       DEPLOY_IMG=-centos-7  TARGET=rpm
 
 services:
   - docker
 
-before_install:
+before_script:
   - docker run
-    --name container
+    --name script
     --detach
     --tty
-    --env SCIDB_VER=${SCIDB_VER}
-    --env SCIDB_INSTALL_PATH=/opt/scidb/${SCIDB_VER}
+    --rm
+    --env SCIDB_VER=$SCIDB_VER
+    --env SCIDB_INSTALL_PATH=/opt/scidb/$SCIDB_VER
     --volume `pwd`:/this
-    ${IMG}
+    $BUILD_IMG
 
 script:
-  - if [ "${TARGET}" = "deb" -o "${TARGET}" = "rpm" ]; then
-    docker exec container sh /this/setup.sh;
-    docker exec container /this/extra-scidb-libs.sh
+  - docker exec script sh /this/setup.sh
+  - docker exec script /this/extra-scidb-libs.sh
     $TARGET
     /root
     tmp
-    1;
+    $PKG_VER
+
+after_script:
+  - docker stop script
+
+before_deploy:
+  - docker run
+    --name deploy
+    --detach
+    --tty
+    --rm
+    --volume `pwd`:/this
+    rvernica/scidb:$SCIDB_VER$DEPLOY_IMG
+
+deploy:
+  - docker exec deploy sh /this/install.sh --only-prereq
+  - if [ "$TARGET" = "rpm" ]; then
+      docker exec deploy yum install
+        /this/extra-scidb-libs-$SCIDB_VER-$PKG_VER-1.x86_64.rpm;
+    else
+      docker exec deploy dpkg --install
+        /this/extra-scidb-libs-$SCIDB_VER-$PKG_VER.deb;
     fi
-  - if [ "${TARGET}" = "try" ]; then
-    docker exec container sh -c
-    "wget -O - https://paradigm4.github.io/extra-scidb-libs/install.sh | sh";
-    docker exec container sh -c
-    "wget -O - https://paradigm4.github.io/extra-scidb-libs/try.sh | sh";
-    fi
+
+after_deploy:
+  - docker stop deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ after_script:
     rvernica/scidb:$SCIDB_VER$DEPLOY_IMG
   - docker exec deploy sh /this/install.sh --only-prereq
   - if [ "$TARGET" = "rpm" ]; then
-      docker exec deploy yum install
+      docker exec deploy yum install --assumeyes
         /this/extra-scidb-libs-$SCIDB_VER-$PKG_VER-1.x86_64.rpm;
     else
       docker exec deploy dpkg --install

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - docker exec script /this/extra-scidb-libs.sh
     $TARGET
     /root
-    tmp
+    /this
     $PKG_VER
   - docker stop script
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,9 @@ script:
     /root
     tmp
     $PKG_VER
-
-after_script:
   - docker stop script
 
-before_deploy:
+after_script:
   - docker run
     --name deploy
     --detach
@@ -53,8 +51,6 @@ before_deploy:
     --rm
     --volume `pwd`:/this
     rvernica/scidb:$SCIDB_VER$DEPLOY_IMG
-
-deploy:
   - docker exec deploy sh /this/install.sh --only-prereq
   - if [ "$TARGET" = "rpm" ]; then
       docker exec deploy yum install
@@ -63,6 +59,4 @@ deploy:
       docker exec deploy dpkg --install
         /this/extra-scidb-libs-$SCIDB_VER-$PKG_VER.deb;
     fi
-
-after_deploy:
   - docker stop deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+branches:
+  only:
+  - gh-pages
+  - /.*/
+
+sudo: required
+
+language: python
+
+python:
+  - "3.6"
+
+env:
+  global: SCIDB_VER=18.1
+  matrix:
+    - IMG=debian:8                              TARGET=deb
+    - IMG=ubuntu:trusty                         TARGET=deb
+    - IMG=centos:6                              TARGET=rpm
+    - IMG=rvernica/scidb:${SCIDB_VER}           TARGET=try
+    - IMG=rvernica/scidb:${SCIDB_VER}-trusty    TARGET=try
+    - IMG=rvernica/scidb:${SCIDB_VER}-centos-6  TARGET=try
+    - IMG=rvernica/scidb:${SCIDB_VER}-centos-7  TARGET=try
+
+services:
+  - docker
+
+before_install:
+  - docker run
+    --name container
+    --detach
+    --tty
+    --env SCIDB_VER=${SCIDB_VER}
+    --env SCIDB_INSTALL_PATH=/opt/scidb/${SCIDB_VER}
+    --volume `pwd`:/this
+    ${IMG}
+
+script:
+  - if [ "${TARGET}" = "deb" -o "${TARGET}" = "rpm" ]; then
+    docker exec container sh /this/setup.sh;
+    docker exec container /this/extra-scidb-libs.sh
+    $TARGET
+    /root
+    tmp
+    1;
+    fi
+  - if [ "${TARGET}" = "try" ]; then
+    docker exec container sh -c
+    "wget -O - https://paradigm4.github.io/extra-scidb-libs/install.sh | sh";
+    docker exec container sh -c
+    "wget -O - https://paradigm4.github.io/extra-scidb-libs/try.sh | sh";
+    fi

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The packages themselves have also been uploaded here for convenience, but to be 
 e.g.
 
 ```sh
-./extra-scidb-libs rpm ~ /tmp 0  # builds and rpm package, deposits it in /tmp using the home directory as the place to do the 
+./extra-scidb-libs rpm ~ /tmp 0  # builds and rpm package, deposits it in /tmp using the home directory as the place to do the
                                  # compling and packaging.  The version is 0.
 ```
 
-To build for rpm, one should build on a CentOS 6 system as most of our plugins need to be compiled on the same platfrom as SciDB itself - which is CentOS 6. Also see dependencies below. 
+To build for rpm, one should build on a CentOS 6 system as most of our plugins need to be compiled on the same platfrom as SciDB itself - which is CentOS 6. Also see dependencies below.
 
 Similarly, for debian packages, one should run the script on Ubuntu 14.04.
 
@@ -56,7 +56,7 @@ This should work for any plugin that builds a `.so` and wants it copied to `$SCI
 
 # Dependencies
 
-You might need to install `rpmdevtools` for Centos 
+You might need to install `rpmdevtools` for Centos
 
 ```sh
 sudo yum install rpm-build rpmdevtools

--- a/extra-scidb-libs.sh
+++ b/extra-scidb-libs.sh
@@ -87,11 +87,11 @@ rm -rf $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
 mkdir -p $work_dir/extra-scidb-libs-${SCIDB_VER:=18.1}-$PKG_VER
 
 # The following array should contain tuples of the repo name and the branch to get.
-declare -a libs=("superfunpack" "rel18.1.1"
-                 "grouped_aggregate" "rel18.1.1"
-                 "accelerated_io_tools" "rel18.1.1"
-                 "equi_join" "rel18.1.1"
-                 "shim" "rel18.1.1"
+declare -a libs=("superfunpack"         "remove-pcre-flag"
+                 "grouped_aggregate"    "rel18.1.1"
+                 "accelerated_io_tools" "master"
+                 "equi_join"            "rel18.1.1"
+                 "shim"                 "rel18.1.1"
                 )
 
 downloadLibs "${libs[@]}"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Args:
+#     --only-prereq: only install prerequisites, skip installing
+#                    extra-scidb-libs
+
 set -o errexit
 
 ARROW_VER=0.9.0-1
@@ -58,10 +62,12 @@ then
     echo "Step 2. Install prerequisites"
     yum install --assumeyes arrow-devel-$ARROW_VER.el6
 
-    echo "Step 3. Install extra-scidb-libs"
-    yum install --assumeyes \
-        https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1-1.x86_64.rpm
-
+    if [ "$1" != "--only-prereq" ]
+    then
+        echo "Step 3. Install extra-scidb-libs"
+        yum install --assumeyes \
+            https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1-1.x86_64.rpm
+    fi
 else
     # Debian/Ubuntu
 
@@ -84,8 +90,11 @@ APT_LINE
     apt-get update
     apt-get install --assume-yes --no-install-recommends libarrow-dev=$ARROW_VER
 
-    echo "Step 3. Install extra-scidb-libs"
-    wget --output-document /tmp/extra-scidb-libs-18.1-1.deb \
-        https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1.deb
-    dpkg --install /tmp/extra-scidb-libs-18.1-1.deb
+    if [ "$1" != "--only-prereq" ]
+    then
+        echo "Step 3. Install extra-scidb-libs"
+        wget --output-document /tmp/extra-scidb-libs-18.1-1.deb \
+            https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1.deb
+        dpkg --install /tmp/extra-scidb-libs-18.1-1.deb
+    fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+set -o errexit
+
+ARROW_VER=0.9.0-1
+
+
+install_lsb_release()
+{
+    echo "Step 0. Install lsb_release"
+
+    # Check if yum or apt-get is available
+    ( which yum                                                       \
+      >  /dev/null                                                    \
+      2>&1 )                                                          \
+    || ( which apt-get                                                \
+         >  /dev/null                                                 \
+         2>&1 )                                                       \
+    || ( echo "yum or apt-get not detected. Unsuported distribution." \
+         && exit 1 )
+
+    # Assume RedHat/CentOS first. If it fails assume Ubuntu/Debian.
+    ( which yum                                    \
+      >  /dev/null                                 \
+      2>&1                                         \
+      && yum install --assumeyes redhat-lsb-core ) \
+    || ( which apt-get                             \
+         >  /dev/null                              \
+         2>&1                                      \
+         && apt-get update                         \
+         && apt-get install --assume-yes lsb-release )
+}
+
+
+which lsb_release      \
+>  /dev/null           \
+2>&1                   \
+|| install_lsb_release
+
+dist=`lsb_release --id | cut --fields=2`
+rel=`lsb_release --release | cut --fields=2 | cut --delimiter=. --fields=1`
+
+
+if [ "$dist" = "CentOS" ]
+then
+    # CentOS
+
+    echo "Step 1. Configure prerequisites repositories"
+    yum repolist               \
+    |  grep epel               \
+    || yum install --assumeyes \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-$rel.noarch.rpm
+
+    yum install --assumeyes wget
+    wget --output-document /etc/yum.repos.d/bintray-rvernica-rpm.repo \
+         https://bintray.com/rvernica/rpm/rpm
+
+    echo "Step 2. Install prerequisites"
+    yum install --assumeyes arrow-devel-$ARROW_VER.el6
+
+    echo "Step 3. Install extra-scidb-libs"
+    yum install --assumeyes \
+        https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1-1.x86_64.rpm
+
+else
+    # Debian/Ubuntu
+
+    echo "Step 1. Configure prerequisites repositories"
+    apt-get update
+    apt-get install                             \
+        --assume-yes                            \
+        --no-install-recommends                 \
+        apt-transport-https                     \
+        ca-certificates                         \
+        gnupg-curl                              \
+        wget
+
+    cat <<APT_LINE | tee /etc/apt/sources.list.d/bintray-rvernica.list
+deb https://dl.bintray.com/rvernica/deb trusty universe
+APT_LINE
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 46BD98A354BA5235
+
+    echo "Step 2. Install prerequisites"
+    apt-get update
+    apt-get install --assume-yes --no-install-recommends libarrow-dev=$ARROW_VER
+
+    echo "Step 3. Install extra-scidb-libs"
+    wget --output-document /tmp/extra-scidb-libs-18.1-1.deb \
+        https://paradigm4.github.io/extra-scidb-libs/extra-scidb-libs-18.1-1.deb
+    dpkg --install /tmp/extra-scidb-libs-18.1-1.deb
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+
+set -o errexit
+
+ARROW_VER=0.9.0-1
+
+
+install_lsb_release()
+{
+    echo "Step 0. Install lsb_release"
+
+    # Check if yum or apt-get is available
+    ( which yum                                                       \
+      >  /dev/null                                                    \
+      2>&1 )                                                          \
+    || ( which apt-get                                                \
+         >  /dev/null                                                 \
+         2>&1 )                                                       \
+    || ( echo "yum or apt-get not detected. Unsuported distribution." \
+         && exit 1 )
+
+    # Assume RedHat/CentOS first. If it fails assume Ubuntu/Debian.
+    ( which yum                                    \
+      >  /dev/null                                 \
+      2>&1                                         \
+      && yum install --assumeyes redhat-lsb-core ) \
+    || ( which apt-get                             \
+         >  /dev/null                              \
+         2>&1                                      \
+         && apt-get update                         \
+         && apt-get install --assume-yes lsb-release )
+}
+
+
+which lsb_release      \
+>  /dev/null           \
+2>&1                   \
+|| install_lsb_release
+
+dist=`lsb_release --id | cut --fields=2`
+rel=`lsb_release --release | cut --fields=2 | cut --delimiter=. --fields=1`
+
+
+if [ "$dist" = "CentOS" ]
+then
+    # CentOS
+
+    echo "Step 1. Configure prerequisites repositories"
+    yum repolist               \
+    |  grep epel               \
+    || yum install --assumeyes \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-$rel.noarch.rpm
+
+    yum install --assumeyes centos-release-scl
+
+    yum install --assumeyes wget
+    wget --output-document /etc/yum.repos.d/bintray-rvernica-rpm.repo \
+         https://bintray.com/rvernica/rpm/rpm
+
+    cat <<EOF | tee /etc/yum.repos.d/scidb.repo
+[scidb]
+name=SciDB repository
+baseurl=https://downloads.paradigm4.com/community/18.1/centos6.3
+gpgkey=https://downloads.paradigm4.com/key
+gpgcheck=1
+enabled=1
+EOF
+
+    echo "Step 2. Install prerequisites"
+    for pkg in arrow-devel-$ARROW_VER.el6 \
+               devtoolset-3-runtime       \
+               devtoolset-3-toolchain     \
+               gcc                        \
+               git                        \
+               libpqxx-devel              \
+               log4cxx-devel              \
+               pcre-devel                 \
+               protobuf-devel-2.4.1       \
+               rpm-build                  \
+               rpmdevtools                \
+               scidb-18.1-dev             \
+               scidb-18.1-libboost-devel  \
+               zlib-devel
+    do
+        yum install --assumeyes $pkg
+    done
+
+else
+    # Debian/Ubuntu
+
+    echo "Step 1. Configure prerequisites repositories"
+    apt-get update
+    apt-get install                             \
+        --assume-yes                            \
+        --no-install-recommends                 \
+        apt-transport-https                     \
+        ca-certificates                         \
+        gnupg-curl
+
+    if [ "$dist" = "Debian" ]
+    then
+        cat <<APT_LINE | tee /etc/apt/sources.list.d/trusty-main.list
+deb http://archive.ubuntu.com/ubuntu/ trusty main
+APT_LINE
+        apt-key adv --keyserver keyserver.ubuntu.com  --recv-keys \
+            3B4FE6ACC0B21F32
+    else
+        cat <<APT_LINE | tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test-trusty.list
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main
+APT_LINE
+        apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv \
+            1E9377A2BA9EF27F
+    fi
+
+    cat <<APT_LINE | tee /etc/apt/sources.list.d/scidb.list
+deb https://downloads.paradigm4.com/ community/18.1/ubuntu14.04/
+APT_LINE
+     apt-key adv --fetch-keys https://downloads.paradigm4.com/key
+
+    cat <<APT_LINE | tee /etc/apt/sources.list.d/bintray-rvernica.list
+deb https://dl.bintray.com/rvernica/deb trusty universe
+APT_LINE
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 46BD98A354BA5235
+
+    echo "Step 2. Install prerequisites"
+    apt-get update
+    apt-get install                             \
+        --assume-yes                            \
+        --no-install-recommends                 \
+        g++                                     \
+        git                                     \
+        liblog4cxx10-dev                        \
+        libarrow-dev=$ARROW_VER                 \
+        libpcre3-dev                            \
+        libpqxx-dev                             \
+        libprotobuf-dev                         \
+        m4                                      \
+        make                                    \
+        scidb-18.1-dev                          \
+        scidb-18.1-libboost1.54-dev             \
+        scidb-18.1-libboost-system1.54-dev
+
+    if [ "$dist" = "Ubuntu" ]
+    then
+        apt-get install                         \
+            --assume-yes                        \
+            --no-install-recommends             \
+            g++-4.9
+    fi
+fi

--- a/try.sh
+++ b/try.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+iquery --afl --query "load_library('accelerated_io_tools')"
+iquery --afl --query "load_library('grouped_aggregate')"
+iquery --afl --query "load_library('equi_join')"
+iquery --afl --query "load_library('superfunpack')"


### PR DESCRIPTION
Highlights:
* Setup script to set the package build environment. Detects the distribution and installs all the required packages in order to build the `extra-scidb-libs` package. Includes Apache Arrow
* Install script to be used by end-user. Detects the distribution and installs the `extra-scidb-libs` dependencies, mainly Apache Arrow and then the `extra-scidb-libs` package. Can be run directly using `wget ... | sh`
* TravisCI file to build the package in Ubuntu and CentOS 6 and try to install it on Debian, Ubuntu, CentOS 6 and CentOS 7 all with SciDB already installed. Uses a "try" script to load the plugins in SciDB.
